### PR TITLE
Add Numbers API integration with fact type selection

### DIFF
--- a/app/controllers/numbers_controller.rb
+++ b/app/controllers/numbers_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class NumbersController < ApplicationController
+  include HTTParty
+  base_uri 'http://numbersapi.com'
+
+  def index; end
+
+  def create
+    value = params[:value].to_s.strip
+    type = params[:type] || 'trivia'
+
+    fact = fetch_fact(value, type)
+
+    if fact
+      render partial: 'numbers/result', locals: { fact: fact }
+    else
+      render_error(value, type)
+    end
+  end
+
+  private
+
+  def fetch_fact(value, type)
+    response = self.class.get("/#{value}/#{type}", query: { json: true })
+
+    response.success? ? response.parsed_response['text'] : nil
+  rescue StandardError => e
+    Rails.logger.error("NumbersAPI error: #{e.message}")
+    nil
+  end
+
+  def render_error(value, type)
+    render turbo_stream: turbo_stream.replace(
+      'numbers_result',
+      "<div class='text-red-600'>Could not fetch a #{type} fact for “#{value}”.</div>"
+    )
+  end
+end

--- a/app/views/numbers/_result.html.erb
+++ b/app/views/numbers/_result.html.erb
@@ -1,0 +1,6 @@
+<%= turbo_frame_tag "numbers_result" do %>
+  <div class="mt-6 p-4 border rounded bg-green-50 shadow">
+    <h2 class="text-xl font-bold mb-2">📘 Did you know?</h2>
+    <p class="text-lg"><%= fact %></p>
+  </div>
+<% end %>

--- a/app/views/numbers/index.html.erb
+++ b/app/views/numbers/index.html.erb
@@ -1,0 +1,23 @@
+<h1 class="text-3xl font-bold mb-6">🔢 Numbers API</h1>
+
+<div data-controller="form" data-action="turbo:submit-start->form#submit turbo:submit-end->form#reset">
+  <%= form_with url: numbers_path, method: :post, data: { turbo_frame: "numbers_result" }, class: "space-y-4" do |form| %>
+    <%= form.label :value, "Enter a number (or a date like 6/14)", class: "block font-semibold" %>
+    <%= form.text_field :value, class: "border rounded px-4 py-2 w-full" %>
+
+    <%= form.label :type, "Choose fact type", class: "block font-semibold" %>
+    <%= form.select :type, ["trivia", "math", "date", "year"], {}, class: "border rounded px-4 py-2 w-full" %>
+
+    <div class="flex items-center gap-4">
+      <%= form.submit "Get Fact", class: "bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 transition", data: { form_target: "button" } %>
+
+      <span class="text-sm text-gray-500 hidden" data-form-target="loading">
+        🧠 Fetching a fact...
+      </span>
+    </div>
+  <% end %>
+</div>
+
+<%= turbo_frame_tag "numbers_result" do %>
+  <p class="text-gray-500 mt-4">Type a number or date and get a fun fact!</p>
+<% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -8,7 +8,7 @@
       <%= link_to "🍔 Recipes", recipes_path, class: "text-blue-600 hover:underline" %>
       <%= link_to "📚 Books", books_path, class: "text-blue-600 hover:underline" %>
       <%= link_to "😂 Jokes", jokes_path, class: "text-blue-600 hover:underline" %>
-      <%= link_to "🔢 Numbers", "numbers_path", class: "text-blue-600 hover:underline" %>
+      <%= link_to "🔢 Numbers", numbers_path, class: "text-blue-600 hover:underline" %>
       <%= link_to "❓ Trivia", "trivia_path", class: "text-blue-600 hover:underline" %>
       <%= link_to "🌍 Countries", "countries_path", class: "text-blue-600 hover:underline" %>
     </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   resources :recipes, only: [:index, :create]
   resources :books, only: [:index, :create]
   resources :jokes, only: [:index, :create]
+  resources :numbers, only: [:index, :create]
 
   # Health check
   get "up" => "rails/health#show", as: :rails_health_check


### PR DESCRIPTION
This PR adds the Numbers API feature to APIpalooza. Users can:

- Enter a number or date
- Select a fact type: trivia, math, year, or date
- Submit via Turbo, with Stimulus-powered loading feedback
- See results rendered in a styled Turbo frame
