### PR TITLE
Add RSpec test coverage for all service classes and weather refresh job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+  gem 'webmock'
 end
 
 gem 'turbo-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,9 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     crass (1.0.6)
     csv (3.3.3)
     date (3.4.1)
@@ -125,6 +128,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashdiff (1.1.0)
     httparty (0.23.1)
       csv
       mini_mime (>= 1.0.0)
@@ -294,6 +298,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.23.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.11)
     websocket-driver (0.7.7)
       base64
@@ -329,6 +337,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webmock
 
 RUBY VERSION
    ruby 3.2.4p170

--- a/spec/jobs/weather_refresh_all_job_spec.rb
+++ b/spec/jobs/weather_refresh_all_job_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WeatherRefreshAllJob, type: :job do
+  let!(:snapshot) { WeatherSnapshot.create(city: "London", temperature: 10, condition: "cloudy", humidity: 60, wind_speed: 5.0, fetched_at: 1.hour.ago) }
+  let(:api_key) { ENV["OPENWEATHER_API_KEY"] }
+
+  describe "#perform" do
+    context "when the API returns a successful response" do
+      before do
+        stub_request(:get, "https://api.openweathermap.org/data/2.5/weather")
+          .with(query: { q: "London", appid: api_key, units: "metric" })
+          .to_return(
+            status: 200,
+            body: {
+              main: { temp: 15.5, humidity: 72 },
+              weather: [{ description: "clear sky" }],
+              wind: { speed: 3.1 }
+            }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+      end
+
+      it "updates the weather snapshot" do
+        expect {
+          described_class.perform_now
+          snapshot.reload
+        }.to change { snapshot.temperature }.from(10).to(15.5)
+         .and change { snapshot.condition }.from("cloudy").to("clear sky")
+      end
+    end
+
+    context "when the API returns a non-success response" do
+      before do
+        stub_request(:get, "https://api.openweathermap.org/data/2.5/weather")
+          .with(query: hash_including(q: "London"))
+          .to_return(status: 500)
+      end
+
+      it "does not update the snapshot" do
+        expect {
+          described_class.perform_now
+          snapshot.reload
+        }.not_to change { snapshot.updated_at }
+      end
+    end
+
+    context "when an exception occurs during the request" do
+      before do
+        stub_request(:get, "https://api.openweathermap.org/data/2.5/weather")
+          .with(query: hash_including(q: "London"))
+          .to_raise(StandardError.new("timeout"))
+      end
+
+      it "logs the error and continues" do
+        expect(Rails.logger).to receive(:error).with(/❌ Error updating London: timeout/)
+        described_class.perform_now
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,7 +1,10 @@
-# This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
+require 'webmock/rspec'
+WebMock.disable_net_connect!(allow_localhost: true)
+
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
+
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 # Uncomment the line below in case you have `--require rails_helper` in the `.rspec` file
@@ -32,6 +35,7 @@ begin
 rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [

--- a/spec/services/books/fetcher_spec.rb
+++ b/spec/services/books/fetcher_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Books::Fetcher do
+  describe '#call' do
+    let(:query) { 'Harry Potter' }
+    let(:fetcher) { described_class.new(query) }
+
+    context 'when the API responds successfully' do
+      let(:response_body) do
+        {
+          'docs' => Array.new(10) { |i| { 'title' => "Book #{i + 1}" } }
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, 'https://openlibrary.org/search.json')
+          .with(query: { q: query })
+          .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns the first 9 book results' do
+        results = fetcher.call
+        expect(results.size).to eq(9)
+        expect(results.first['title']).to eq('Book 1')
+      end
+    end
+
+    context 'when the API returns an error' do
+      before do
+        stub_request(:get, 'https://openlibrary.org/search.json')
+          .with(query: { q: query })
+          .to_return(status: 500)
+      end
+
+      it 'returns nil' do
+        expect(fetcher.call).to be_nil
+      end
+    end
+
+    context 'when an exception is raised' do
+      before do
+        allow(described_class).to receive(:get).and_raise(StandardError.new('Boom'))
+      end
+
+      it 'logs the error and returns nil' do
+        expect(Rails.logger).to receive(:error).with(/OpenLibrary error: Boom/)
+        expect(fetcher.call).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/jokes/fetcher_spec.rb
+++ b/spec/services/jokes/fetcher_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Jokes::Fetcher do
+  describe '.fetch' do
+    let(:category) { 'Programming' }
+
+    context 'when the API responds successfully' do
+      let(:response_body) do
+        {
+          'type' => 'single',
+          'joke' => 'Why do programmers prefer dark mode? Because light attracts bugs!'
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, "https://v2.jokeapi.dev/joke/#{category}")
+          .with(query: { format: 'json' })
+          .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns the parsed joke' do
+        result = described_class.fetch(category)
+        expect(result['joke']).to include('dark mode')
+      end
+    end
+
+    context 'when the API request fails' do
+      before do
+        stub_request(:get, "https://v2.jokeapi.dev/joke/#{category}")
+          .with(query: { format: 'json' })
+          .to_return(status: 500)
+      end
+
+      it 'returns nil' do
+        expect(described_class.fetch(category)).to be_nil
+      end
+    end
+
+    context 'when an exception is raised' do
+      before do
+        allow(described_class).to receive(:get).and_raise(StandardError.new('oops'))
+      end
+
+      it 'logs the error and returns nil' do
+        expect(Rails.logger).to receive(:error).with(/JokeAPI error: oops/)
+        expect(described_class.fetch(category)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/numbers/fact_fetcher_spec.rb
+++ b/spec/services/numbers/fact_fetcher_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Numbers::FactFetcher do
+  describe '#call' do
+    let(:value) { '42' }
+    let(:type) { 'trivia' }
+
+    context 'when the API responds successfully' do
+      let(:response_body) { { 'text' => '42 is the answer to life.' }.to_json }
+
+      before do
+        stub_request(:get, "http://numbersapi.com/#{value}/#{type}")
+          .with(query: { json: true })
+          .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns the fact text' do
+        fact = described_class.new(value: value, type: type).call
+        expect(fact).to eq('42 is the answer to life.')
+      end
+    end
+
+    context 'when the API request fails' do
+      before do
+        stub_request(:get, "http://numbersapi.com/#{value}/#{type}")
+          .with(query: { json: true })
+          .to_return(status: 500, body: '')
+      end
+
+      it 'returns nil' do
+        fact = described_class.new(value: value, type: type).call
+        expect(fact).to be_nil
+      end
+    end
+
+    context 'when an exception occurs' do
+      before do
+        allow(described_class).to receive(:get).and_raise(StandardError.new('something went wrong'))
+      end
+
+      it 'logs the error and returns nil' do
+        expect(Rails.logger).to receive(:error).with(/NumbersAPI error: something went wrong/)
+        fact = described_class.new(value: value, type: type).call
+        expect(fact).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/recipes/fetcher_spec.rb
+++ b/spec/services/recipes/fetcher_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Recipes::Fetcher do
+  let(:keyword) { 'pasta' }
+  let(:api_key) { 'fake-key' }
+  let(:basic_recipe) { { 'id' => 123, 'title' => 'Spaghetti' } }
+  let(:detailed_recipe) { { 'title' => 'Spaghetti', 'instructions' => 'Boil water...' } }
+
+  subject(:service) { described_class.new(keyword) }
+
+  before do
+    stub_const('ENV', ENV.to_h.merge('SPOONACULAR_API_KEY' => api_key))
+    Rails.cache.clear
+  end
+
+  describe '#call' do
+    context 'when both API calls are successful' do
+      before do
+        stub_request(:get, 'https://api.spoonacular.com/recipes/complexSearch')
+          .with(query: { query: keyword, number: 6 }, headers: { 'x-api-key' => api_key })
+          .to_return(status: 200, body: { results: [basic_recipe] }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+        stub_request(:get, 'https://api.spoonacular.com/recipes/123/information')
+          .with(headers: { 'x-api-key' => api_key })
+          .to_return(status: 200, body: detailed_recipe.to_json, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns detailed recipes' do
+        result = service.call
+        expect(result).to be_an(Array)
+        expect(result.first['title']).to eq('Spaghetti')
+        expect(result.first['instructions']).to eq('Boil water...')
+      end
+    end
+
+    context 'when basic recipe fetch fails' do
+      before do
+        stub_request(:get, 'https://api.spoonacular.com/recipes/complexSearch')
+          .with(query: { query: keyword, number: 6 }, headers: { 'x-api-key' => api_key })
+          .to_return(status: 500)
+      end
+
+      it 'returns nil' do
+        expect(service.call).to be_nil
+      end
+    end
+
+    context 'when detail recipe fetch fails' do
+      before do
+        stub_request(:get, 'https://api.spoonacular.com/recipes/complexSearch')
+          .with(query: { query: keyword, number: 6 }, headers: { 'x-api-key' => api_key })
+          .to_return(
+            status: 200,
+            body: { results: [basic_recipe] }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        stub_request(:get, 'https://api.spoonacular.com/recipes/123/information')
+          .with(headers: { 'x-api-key' => api_key })
+          .to_return(status: 500)
+      end
+
+      it 'returns a fallback recipe' do
+        result = service.call
+        expect(result.first['title']).to eq('Spaghetti')
+        expect(result.first['error']).to be true
+      end
+    end
+  end
+end

--- a/spec/services/weather/fetcher_spec.rb
+++ b/spec/services/weather/fetcher_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Weather::Fetcher do
+  let(:city) { 'Gotham' }
+  let(:api_key) { 'fake-key' }
+  let(:service) { described_class.new(city) }
+
+  before do
+    stub_const('ENV', ENV.to_h.merge('OPENWEATHER_API_KEY' => api_key))
+    WeatherSnapshot.destroy_all
+  end
+
+  describe '#call' do
+    context 'when a snapshot exists in the DB' do
+      let!(:snapshot) do
+        WeatherSnapshot.create!(
+          city: city,
+          temperature: 22.5,
+          condition: 'cloudy',
+          humidity: 60,
+          wind_speed: 4.2,
+          fetched_at: Time.current
+        )
+      end
+
+      it 'returns the formatted snapshot' do
+        result = service.call
+
+        expect(result).to match(
+          a_hash_including(
+            'name' => city,
+            'main' => {
+              'temp' => 22.5,
+              'humidity' => 60
+            },
+            'weather' => [a_hash_including('description' => 'cloudy')],
+            'wind' => { 'speed' => 4.2 }
+          )
+        )
+      end
+    end
+
+    context 'when no snapshot exists and API call succeeds' do
+      let(:api_response) do
+        {
+          'main' => { 'temp' => 30.0, 'humidity' => 50 },
+          'weather' => [{ 'description' => 'sunny' }],
+          'wind' => { 'speed' => 3.5 },
+          'name' => city
+        }
+      end
+
+      before do
+        stub_request(:get, 'https://api.openweathermap.org/data/2.5/weather')
+          .with(query: { q: city, appid: api_key, units: 'metric' })
+          .to_return(status: 200, body: api_response.to_json, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns the API data and stores it in the DB' do
+        result = service.call
+
+        expect(result['main']['temp']).to eq(30.0)
+        expect(result['weather'].first['description']).to eq('sunny')
+
+        snapshot = WeatherSnapshot.find_by(city: city)
+        expect(snapshot).to have_attributes(
+          temperature: 30.0,
+          condition: 'sunny',
+          humidity: 50,
+          wind_speed: 3.5
+        )
+      end
+    end
+
+    context 'when API call fails' do
+      before do
+        stub_request(:get, 'https://api.openweathermap.org/data/2.5/weather')
+          .with(query: { q: city, appid: api_key, units: 'metric' })
+          .to_return(status: 500, body: 'error')
+      end
+
+      it 'returns fallback data' do
+        result = service.call
+
+        expect(result['main']['temp']).to eq('N/A')
+        expect(result['weather'].first['description']).to eq('Unavailable')
+        expect(result['wind']['speed']).to eq('N/A')
+      end
+    end
+  end
+end

--- a/spec/services/youtube/fetcher_spec.rb
+++ b/spec/services/youtube/fetcher_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Youtube::Fetcher do
+  describe '#call' do
+    let(:query) { 'lofi music' }
+    let(:api_key) { 'fake-api-key' }
+
+    subject(:service) { described_class.new(query) }
+
+    before do
+      stub_const('ENV', ENV.to_h.merge('YOUTUBE_API_KEY' => api_key))
+    end
+
+    context 'when the API responds successfully' do
+      let(:response_body) do
+        {
+          'items' => [
+            {
+              'id' => { 'videoId' => 'abc123' },
+              'snippet' => {
+                'title' => 'Lofi Beats',
+                'thumbnails' => {
+                  'medium' => { 'url' => 'https://img.youtube.com/vi/abc123/mqdefault.jpg' }
+                }
+              }
+            }
+          ]
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, 'https://www.googleapis.com/youtube/v3/search')
+          .with(query: {
+            key: api_key,
+            q: query,
+            part: 'snippet',
+            type: 'video',
+            maxResults: 3
+          })
+          .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns an array of parsed video data' do
+        result = service.call
+
+        expect(result).to be_an(Array)
+        expect(result.first[:title]).to eq('Lofi Beats')
+        expect(result.first[:video_id]).to eq('abc123')
+        expect(result.first[:thumbnail]).to include('youtube')
+      end
+    end
+
+    context 'when the API request fails' do
+      before do
+        stub_request(:get, 'https://www.googleapis.com/youtube/v3/search')
+          .with(query: hash_including(q: query))
+          .to_return(status: 500)
+      end
+
+      it 'returns an empty array' do
+        expect(service.call).to eq([])
+      end
+    end
+
+    context 'when an exception occurs' do
+      before do
+        allow(Youtube::Fetcher).to receive(:get).and_raise(StandardError.new('network error'))
+      end
+
+      it 'logs the error and returns an empty array' do
+        expect(Rails.logger).to receive(:error).with(/YouTube API exception: network error/)
+        expect(service.call).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds comprehensive RSpec tests for all service objects and the WeatherRefreshAllJob. Covered cases include:
- Service Specs:
    Numbers::FactFetcher
    Books::Fetcher
    Jokes::Fetcher
    Youtube::Fetcher
    Recipes::Fetcher
    Weather::Fetcher
- Job Spec:
    WeatherRefreshAllJob