### PR TITLE
Prepare app for free Render deployment (disable scheduler, add rake fallback)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,22 @@ This app demonstrates different backend techniques across each API integration t
 
 Each controller and service was written with clarity and testability in mind, and all core logic is covered by RSpec tests.
 
+## 🚀 Render Deployment Strategy
 
+To make this app deployable on [Render's free tier](https://render.com), we made a few key adjustments:
+
+- **ActiveJob runs inline in production**  
+  Background jobs are executed immediately, instead of requiring a Sidekiq worker.
+
+- **Sidekiq Scheduler is disabled in production**  
+  Our job schedule is defined in `config/sidekiq_schedule.yml`, but it's only loaded in development to avoid breaking free-tier hosting.
+
+- **Manual Rake Task as an Alternative to Cron**  
+  Instead of automatic job scheduling, you can manually refresh weather data anytime using the command below:
+
+```bash
+bin/rails weather:refresh_all
+```
 
 ## ✅ Test Coverage
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,97 +1,24 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
-  # Settings specified here will take precedence over those in config/application.rb.
-
-  # Code is not reloaded between requests.
   config.enable_reloading = false
-
-  # Eager load code on boot. This eager loads most of Rails and
-  # your application in memory, allowing both threaded web servers
-  # and those relying on copy on write to perform better.
-  # Rake tasks automatically ignore this option for performance.
   config.eager_load = true
-
-  # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
-
-  # Ensures that a master key has been made available in ENV["RAILS_MASTER_KEY"], config/master.key, or an environment
-  # key such as config/credentials/production.key. This key is used to decrypt credentials (and other encrypted files).
-  # config.require_master_key = true
-
-  # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
-  # config.public_file_server.enabled = false
-
-  # Compress CSS using a preprocessor.
-  # config.assets.css_compressor = :sass
-
-  # Do not fall back to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
-
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.asset_host = "http://assets.example.com"
-
-  # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
-  # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
-
-  # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
-
-  # Mount Action Cable outside main process or domain.
-  # config.action_cable.mount_path = nil
-  # config.action_cable.url = "wss://example.com/cable"
-  # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
-
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
-  # config.assume_ssl = true
-
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)
     .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
     .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 
-  # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
 
-  # "info" includes generic and useful information about system operation, but avoids logging too much
-  # information to avoid inadvertent exposure of personally identifiable information (PII). If you
-  # want to log everything, set the level to "debug".
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
-
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
-
-  # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter = :resque
-  # config.active_job.queue_name_prefix = "ap_ipalooza_production"
-
   config.action_mailer.perform_caching = false
-
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
-
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
-
-  # Don't log any deprecations.
   config.active_support.report_deprecations = false
-
-  # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-
-  # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.active_job.queue_adapter = :inline
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,1 +1,16 @@
+require 'sidekiq'
 require 'sidekiq-scheduler'
+
+if Rails.env.development?
+  Sidekiq.configure_server do |config|
+    config.on(:startup) do
+      schedule_file = Rails.root.join("config/sidekiq_schedule.yml")
+
+      if File.exist?(schedule_file)
+        Sidekiq::Scheduler.dynamic = false
+        Sidekiq.schedule = YAML.load_file(schedule_file)
+        Sidekiq::Scheduler.load_schedule!
+      end
+    end
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,3 @@
-:schedule:
-  weather_refresh_all:
-    cron: "0 * * * *"   # every hour
-    class: "WeatherRefreshAllJob"
-    queue: default
-    
+:concurrency: 5
+:queues:
+  - default

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -1,0 +1,5 @@
+:schedule:
+  weather_refresh_all:
+    cron: "0 0 * * *"
+    class: "WeatherRefreshAllJob"
+    queue: default

--- a/lib/tasks/weather.rake
+++ b/lib/tasks/weather.rake
@@ -1,0 +1,7 @@
+namespace :weather do
+  desc "Refresh all weather snapshots"
+  task refresh_all: :environment do
+    WeatherRefreshAllJob.new.perform
+    puts "✅ Weather snapshots refreshed"
+  end
+end


### PR DESCRIPTION
This PR contains adjustments to make the app deployable on [Render's free tier](https://render.com/):
    Switched ActiveJob to use :inline adapter in production
    Disabled sidekiq-scheduler in production by conditionally loading a schedule file
    Moved schedule into config/sidekiq_schedule.yml for better environment control
    Added a manual rake task weather:refresh_all as an optional replacement for background scheduling
    Keeps Sidekiq + scheduler code to showcase background job knowledge, while ensuring safe deploy on free-tier hosting